### PR TITLE
[feature] add all streaming servers to the list of episode sources

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -123,7 +123,7 @@ app.get("/watch/:id", async (req: any, res: any) => {
   try {
     const episode: string = req.query?.ep as string;
     const id: string = req.params.id + "?ep=" + episode;
-    const data: IEpisodeSources | IError = await fetchEpisodeSource(id);
+    const data: IEpisodeSources[] | IEpisodeSources | IError = await fetchEpisodeSource(id);
     // console.log(id);
 
     res.send(data);

--- a/src/types/aniwatch.d.ts
+++ b/src/types/aniwatch.d.ts
@@ -96,5 +96,6 @@ export type IEpisodeSources = {
     intro: {
         start: number;
         end: number;
-    }
+    },
+    server: string;
 }


### PR DESCRIPTION
Added all available streaming servers to the episode sources list.

With known issue:

StreamSB and StreamTape not working.

Solution for the issue:

Switch to the their particular streaming provider service.

Changes :

Changes to the return type:

Earlier : {
    sources: {
        url: string;
        quality: string;
        isM3U8: boolean;
    }[],
    subTitles: {
        url: string;
        lang: string;
    }[],
    intro: {
        start: number;
        end: number;
    }
}

Now : {
    sources: {
        url: string;
        quality: string;
        isM3U8: boolean;
    }[],
    subTitles: {
        url: string;
        lang: string;
    }[],
    intro: {
        start: number;
        end: number;
    },
    server: string;
}